### PR TITLE
Add functions for: control bus, standby mode, auto power down time

### DIFF
--- a/aiostreammagic/models.py
+++ b/aiostreammagic/models.py
@@ -126,6 +126,9 @@ class State(DataClassORJSONMixin):
     standby_mode: StandbyMode = field(
         metadata=field_options(alias="standby_mode"), default=StandbyMode.NETWORK
     )
+    auto_power_down_time: int = field(
+        metadata=field_options(alias="auto_power_down"), default=1200
+    )
 
 
 @dataclass

--- a/aiostreammagic/models.py
+++ b/aiostreammagic/models.py
@@ -63,6 +63,12 @@ class ControlBusMode(StrEnum):
     RECEIVER = "receiver"
     OFF = "off"
 
+class StandbyMode(StrEnum):
+    """Standby mode"""
+
+    ECO = "ECO_MODE"
+    NETWORK = "NETWORK"
+
 
 @dataclass
 class Info(DataClassORJSONMixin):
@@ -116,6 +122,9 @@ class State(DataClassORJSONMixin):
     )
     control_bus: ControlBusMode = field(
         metadata=field_options(alias="cbus"), default=ControlBusMode.OFF
+    )
+    standby_mode: StandbyMode = field(
+        metadata=field_options(alias="standby_mode"), default=StandbyMode.NETWORK
     )
 
 

--- a/aiostreammagic/stream_magic.py
+++ b/aiostreammagic/stream_magic.py
@@ -625,3 +625,7 @@ class StreamMagicClient:
     async def set_control_bus_mode(self, control_bus: ControlBusMode) -> None:
         """Set the control bus mode."""
         await self.request(ep.ZONE_STATE, params={"cbus": control_bus})
+
+    async def set_standby_mode(self, standby_mode: StandbyMode) -> None:
+        """Set the standby mode."""
+        await self.request(ep.ZONE_STATE, params={"standby_mode": standby_mode})

--- a/aiostreammagic/stream_magic.py
+++ b/aiostreammagic/stream_magic.py
@@ -621,3 +621,7 @@ class StreamMagicClient:
     async def recall_preset(self, preset: int) -> None:
         """Recall a preset for the device."""
         await self.request(ep.RECALL_PRESET, params={"preset": preset, "zone": "ZONE1"})
+
+    async def set_control_bus_mode(self, control_bus: ControlBusMode) -> None:
+        """Set the control bus mode."""
+        await self.request(ep.ZONE_STATE, params={"cbus": control_bus})

--- a/aiostreammagic/stream_magic.py
+++ b/aiostreammagic/stream_magic.py
@@ -629,3 +629,7 @@ class StreamMagicClient:
     async def set_standby_mode(self, standby_mode: StandbyMode) -> None:
         """Set the standby mode."""
         await self.request(ep.ZONE_STATE, params={"standby_mode": standby_mode})
+
+    async def set_auto_power_down(self, auto_power_down_time_seconds: int) -> None:
+        """Set the automatic power down time."""
+        await self.request(ep.POWER, params={"auto_power_down": auto_power_down_time_seconds})


### PR DESCRIPTION
### About

In the Home Assistant integration I have noticed that volume can not be controlled when pre_amp_mode is disabled. 
In the StreamMagic app, the volume can still be controlled when PreAmp mode is disabled but the Control Bus mode is "Amplifier". It then controls the control bus volume and so changes volume on the connected amplifier. In the app you can of course not see the current volume state because control bus is uni-directional.

I have looked into the code of the Home Assistant integration and found that the ControlBusMode in the "state" property is not even accounted for and that the volume controls (PREAMP_FEATURES) are only added when pre-amp mode is enabled. I would like to change that.
So as a first step it is necessary that aiostreammagic has the ability to control the control bus mode.

Originally I _only_ wanted to add Control Bus Mode, but since I was at it already, I also added standby_mode and auto_power_down
just to get more in alignment to the StreamMagic app. 
I'm aware that controlling standby_mode lets you lock yourself out of the ability to control it over the network, but since the StreamMagic App also offers it, I wanted to offer the addition (commit will be dropped if desired). Adding the control of this setting to the Home Assistant integration is a more critical decision.