### PR TITLE
Update supported devices list & add host variable to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This module implements a Python client for the Stream Magic API used to control 
 - Cambridge Audio Evo 75
 - Cambridge Audio Evo 150
 - Cambridge Audio CXN
-- Cambridge Audio CXN (v2)
+- Cambridge Audio CXN V2
+- Cambridge Audio CXN100
 - Cambridge Audio CXR120
 - Cambridge Audio CXR200
 - Cambridge Audio 851N
@@ -52,7 +53,7 @@ HOST = "192.168.20.218"
 
 async def main():
     """Basic demo entrypoint."""
-    client = StreamMagicClient("192.168.20.218")
+    client = StreamMagicClient(HOST)
     await client.connect()
 
     info: Info = await client.get_info()
@@ -90,7 +91,7 @@ async def on_state_change(client: StreamMagicClient):
 
 async def main():
     """Subscribe demo entrypoint."""
-    client = StreamMagicClient("192.168.20.218")
+    client = StreamMagicClient(HOST)
     await client.register_state_update_callbacks(on_state_change)
     await client.connect()
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,12 +2,12 @@ import asyncio
 
 from aiostreammagic import StreamMagicClient, Source, Info
 
-HOST = "192.168.20.218"
+HOST = "192.168.x.x"  # Replace with your StreamMagic device's IP address
 
 
 async def main() -> None:
     """Basic demo entrypoint."""
-    client = StreamMagicClient("192.168.20.218")
+    client = StreamMagicClient(HOST)
     await client.connect()
 
     info: Info = await client.get_info()

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -3,7 +3,7 @@ import asyncio
 from aiostreammagic.stream_magic import StreamMagicClient
 from aiostreammagic.models import CallbackType
 
-HOST = "192.168.20.218"
+HOST = "192.168.x.x"  # Replace with your StreamMagic device's IP address
 
 
 async def on_state_change(
@@ -22,7 +22,7 @@ async def on_state_change(
 
 async def main() -> None:
     """Subscribe demo entrypoint."""
-    client = StreamMagicClient("192.168.20.218")
+    client = StreamMagicClient(HOST)
     await client.register_state_update_callbacks(on_state_change)
     await client.connect()
 


### PR DESCRIPTION
- Add CXN100 to readme, update CXN V2 to match description on Cambridge website
- Use HOST variable for connection examples