### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 ]
 docs = [
     "pdoc>=14.7,<16.0"
+]
 
 [tool.mypy]
 # Specify the target platform details in config, so your developers are


### PR DESCRIPTION
This is a bit embarassing. I seem to have removed the bracket when resolving the merge conflicts... 