### PR TITLE
Allow preserving injected aiohttp sessions and add websocket heartbeat

### DIFF
--- a/aiostreammagic/stream_magic.py
+++ b/aiostreammagic/stream_magic.py
@@ -34,13 +34,22 @@ from aiostreammagic.util import eq_bands_to_param_string
 from . import endpoints as ep
 from .const import _LOGGER
 
+_WEBSOCKET_HEARTBEAT = 30.0
+
 
 class StreamMagicClient:
     """Client for handling connections with StreamMagic enabled devices."""
 
-    def __init__(self, host: str, session: ClientSession | None = None) -> None:
+    def __init__(
+        self,
+        host: str,
+        session: ClientSession | None = None,
+        *,
+        should_close_session: bool = True,
+    ) -> None:
         self.host = host
         self.session: Optional[ClientSession] = session
+        self._should_close_session: bool = should_close_session
         self.connection: ClientWebSocketResponse | None = None
         self.futures: dict[str, list[Future[Any]]] = {}
         self._subscriptions: dict[str, Any] = {}
@@ -119,9 +128,10 @@ class StreamMagicClient:
             task.cancel()
         await asyncio.gather(*self._subscription_tasks.values(), return_exceptions=True)
         self._subscription_tasks.clear()
-        # Properly close the aiohttp session if it was created by this client
-        if self.session is not None and not self.session.closed:
-            await self.session.close()
+        if self._should_close_session and self.session is not None:
+            if not self.session.closed:
+                await self.session.close()
+            self.session = None
 
     def is_connected(self) -> bool:
         """Return True if device is connected."""
@@ -131,12 +141,14 @@ class StreamMagicClient:
         """Establish a connection with a WebSocket."""
         if self.session is None:
             self.session = ClientSession()
+            self._should_close_session = True
         return await self.session.ws_connect(
             uri,
             headers={
                 "Origin": f"ws://{self.host}",
                 "Host": f"{self.host}:80",
             },
+            heartbeat=_WEBSOCKET_HEARTBEAT,
         )
 
     async def _reconnect_handler(self, res: Future[bool]) -> None:

--- a/tests/test_stream_magic.py
+++ b/tests/test_stream_magic.py
@@ -1,0 +1,80 @@
+from typing import Any, cast
+
+import pytest
+from aiohttp import ClientSession
+
+from aiostreammagic.stream_magic import StreamMagicClient, _WEBSOCKET_HEARTBEAT
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+        self.ws_connect_calls: list[dict[str, Any]] = []
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+
+    async def ws_connect(self, uri: str, **kwargs: Any) -> object:
+        self.ws_connect_calls.append({"uri": uri, "kwargs": kwargs})
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_close_injected_session_when_disabled() -> None:
+    session = FakeSession()
+    client = StreamMagicClient(
+        "192.0.2.10",
+        cast(ClientSession, session),
+        should_close_session=False,
+    )
+
+    await client.disconnect()
+
+    assert session.close_calls == 0
+    assert client.session is session
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_injected_session_by_default() -> None:
+    session = FakeSession()
+    client = StreamMagicClient("192.0.2.10", cast(ClientSession, session))
+
+    await client.disconnect()
+
+    assert session.close_calls == 1
+    assert client.session is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_session_created_by_client() -> None:
+    session = FakeSession()
+    client = StreamMagicClient("192.0.2.10")
+    client.session = cast(ClientSession, session)
+
+    await client.disconnect()
+
+    assert session.close_calls == 1
+    assert client.session is None
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_uses_heartbeat() -> None:
+    session = FakeSession()
+    client = StreamMagicClient("192.0.2.10", cast(ClientSession, session))
+
+    await client._ws_connect("ws://192.0.2.10/smoip")
+
+    assert session.ws_connect_calls == [
+        {
+            "uri": "ws://192.0.2.10/smoip",
+            "kwargs": {
+                "headers": {
+                    "Origin": "ws://192.0.2.10",
+                    "Host": "192.0.2.10:80",
+                },
+                "heartbeat": _WEBSOCKET_HEARTBEAT,
+            },
+        }
+    ]


### PR DESCRIPTION
## Summary

- add a typed `should_close_session` option that defaults to closing the active aiohttp session
- allow shared/injected sessions to be preserved by passing `should_close_session=False`
- pass a 30s heartbeat to `ws_connect()`
- add async regression tests for injected session opt-out, default session closing, owned sessions, and heartbeat wiring

## Context

Home Assistant passes its shared aiohttp session into `StreamMagicClient`. Integrations that share a session can now pass `should_close_session=False` so `disconnect()` does not close the global session, while callers that pass an exclusive session still get the existing managed-close behavior by default. This matches the behavior reported in home-assistant/core#170873.

## Tests

- `uv run --python 3.13 --extra dev pytest -q`
- `uv run --python 3.13 --extra dev ruff format --check .`
- `uv run --python 3.13 --extra dev ruff check .`
- `uv run --python 3.13 --extra dev mypy aiostreammagic tests`