### PR TITLE
 Improve session cleanup logic for reconnects, and add ws heartbeat 

### DIFF
--- a/aiostreammagic/const.py
+++ b/aiostreammagic/const.py
@@ -1,3 +1,5 @@
 import logging
 
 _LOGGER = logging.getLogger(__package__)
+
+WS_HEARTBEAT_TIME = 30.0

--- a/aiostreammagic/stream_magic.py
+++ b/aiostreammagic/stream_magic.py
@@ -32,15 +32,22 @@ from aiostreammagic.models import (
 )
 from aiostreammagic.util import eq_bands_to_param_string
 from . import endpoints as ep
-from .const import _LOGGER
+from .const import _LOGGER, WS_HEARTBEAT_TIME
 
 
 class StreamMagicClient:
     """Client for handling connections with StreamMagic enabled devices."""
 
-    def __init__(self, host: str, session: ClientSession | None = None) -> None:
+    def __init__(
+        self,
+        host: str,
+        session: ClientSession | None = None,
+        *,
+        should_close_session: bool = True,
+    ) -> None:
         self.host = host
         self.session: Optional[ClientSession] = session
+        self._should_close_session: bool = should_close_session
         self.connection: ClientWebSocketResponse | None = None
         self.futures: dict[str, list[Future[Any]]] = {}
         self._subscriptions: dict[str, Any] = {}
@@ -120,12 +127,19 @@ class StreamMagicClient:
         await asyncio.gather(*self._subscription_tasks.values(), return_exceptions=True)
         self._subscription_tasks.clear()
         # Properly close the aiohttp session if it was created by this client
-        if self.session is not None and not self.session.closed:
-            await self.session.close()
+        if self._should_close_session and self.session is not None:
+            if not self.session.closed:
+                await self.session.close()
+            self.session = None
 
     def is_connected(self) -> bool:
         """Return True if device is connected."""
-        return self.connect_task is not None and not self.connect_task.done()
+        return (
+            self.connection is not None
+            and not self.connection.closed
+            and self.connect_task is not None
+            and not self.connect_task.done()
+        )
 
     async def _ws_connect(self, uri: str) -> ClientWebSocketResponse:
         """Establish a connection with a WebSocket."""
@@ -137,6 +151,7 @@ class StreamMagicClient:
                 "Origin": f"ws://{self.host}",
                 "Host": f"{self.host}:80",
             },
+            heartbeat=WS_HEARTBEAT_TIME,
         )
 
     async def _reconnect_handler(self, res: Future[bool]) -> None:
@@ -271,6 +286,9 @@ class StreamMagicClient:
                         subscription_queues[path].put_nowait(msg)
         except (asyncio.CancelledError,):
             pass
+        finally:
+            if self.connection is ws:
+                self.connection = None
 
     async def _send(
         self, path: str, params: Optional[dict[str, str | int | float | bool]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiostreammagic"
-version = "2.13.0"
+version = "2.13.1"
 description = "An async python package for interfacing with Cambridge Audio / Stream Magic compatible streamers."
 authors = [
     { name = "Noah Husby", email = "32528627+noahhusby@users.noreply.github.com" }


### PR DESCRIPTION
Adds ability to determine session cleanup behavior as required for external non-mutable sessions. Additionally adds websocket heartbeat which should trigger a failure earlier if no communication is occurring.